### PR TITLE
Adding Tailwind & Flowbite CSS libraries

### DIFF
--- a/gitignore.txt
+++ b/gitignore.txt
@@ -1,0 +1,1 @@
+node_modules

--- a/index.html
+++ b/index.html
@@ -4,13 +4,14 @@
     <meta charset="UTC-8" />
     <title>English Team</title>
     <link rel="stylesheet" href="style.css" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.3/flowbite.min.css" rel="stylesheet" />
   </head>
 
   <body>
     <div class="logo">
       <img src="imagenes/logo_sd.png" alt="logo SD" />
     </div>
-    
+    <!-- BOTONES DE CONTROL -->
     <div class="buttons">
       <div class="btn robos_btn">
         <div class="robos_logo">
@@ -89,7 +90,7 @@
         <div class="tecnicos_guardia_logo">
           <a href="indice/tecnicos_de_Guardia.html" target="_blank">
             <img
-              src="imagenes/tecnicos_de_Guardia.png"
+              src="imagenes/tecnicos_de_guardia.png"
               alt="Tecnicos de Guardia"
             />
           </a>

--- a/indice/camaras.html
+++ b/indice/camaras.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
 <html lang="es">
+  <head>
+    <meta charset="UTC-8" />
+    <title>English Team</title>
+    <link rel="stylesheet" href="../style.css" />
+    <link
+      href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.3/flowbite.min.css"
+      rel="stylesheet"
+    />
+  </head>
 
-<head>
-<meta charset="UTC-8">
-<title>English Team</title>
-<link rel="stylesheet" href="../style.css">
-</head>
-
-<body>
-
-<div><img src="../imagenes/logo_sd.png" alt="logo SD"></div>
+  <body>
+    <div><img src="../imagenes/logo_sd.png" alt="logo SD" /></div>
+  </body>
+</html>

--- a/indice/classics.html
+++ b/indice/classics.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
 <html lang="es">
+  <head>
+    <meta charset="UTC-8" />
+    <title>English Team</title>
+    <link rel="stylesheet" href="../style.css" />
+    <link
+      href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.3/flowbite.min.css"
+      rel="stylesheet"
+    />
+  </head>
 
-<head>
-<meta charset="UTC-8">
-<title>English Team</title>
-<link rel="stylesheet" href="../style.css">
-</head>
-
-<body>
-
-<div><img src="../imagenes/logo_sd.png" alt="logo SD"></div>
+  <body>
+    <div><img src="../imagenes/logo_sd.png" alt="logo SD" /></div>
+  </body>
+</html>

--- a/indice/facturacion.html
+++ b/indice/facturacion.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
 <html lang="es">
+  <head>
+    <meta charset="UTC-8" />
+    <title>English Team</title>
+    <link rel="stylesheet" href="../style.css" />
+    <link
+      href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.3/flowbite.min.css"
+      rel="stylesheet"
+    />
+  </head>
 
-<head>
-<meta charset="UTC-8">
-<title>English Team</title>
-<link rel="stylesheet" href="../style.css">
-</head>
-
-<body>
-
-<div><img src="../imagenes/logo_sd.png" alt="logo SD"></div>
+  <body>
+    <div><img src="../imagenes/logo_sd.png" alt="logo SD" /></div>
+  </body>
+</html>

--- a/indice/fast.html
+++ b/indice/fast.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang="es">
+  <head>
+    <meta charset="UTC-8" />
+    <title>English Team</title>
+    <link rel="stylesheet" href="../style.css" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.3/flowbite.min.css" rel="stylesheet" />
+  </head>
 
-<head>
-<meta charset="UTC-8">
-<title>English Team</title>
-<link rel="stylesheet" href="../style.css">
-</head>
-
-<body>
-
-<div><img src="../imagenes/logo_sd.png" alt="logo SD"></div>
+  <body>
+    <div><img src="../imagenes/logo_sd.png" alt="logo SD" /></div>
+  </body>
+</html>

--- a/indice/moonshot.html
+++ b/indice/moonshot.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang="es">
+  <head>
+    <meta charset="UTC-8" />
+    <title>English Team</title>
+    <link rel="stylesheet" href="../style.css" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.3/flowbite.min.css" rel="stylesheet"/>
+  </head>
 
-<head>
-<meta charset="UTC-8">
-<title>English Team</title>
-<link rel="stylesheet" href="../style.css">
-</head>
-
-<body>
-
-<div><img src="../imagenes/logo_sd.png" alt="logo SD"></div>
+  <body>
+    <div><img src="../imagenes/logo_sd.png" alt="logo SD" /></div>
+  </body>
+</html>

--- a/indice/tecnicos_de_Guardia.html
+++ b/indice/tecnicos_de_Guardia.html
@@ -1,12 +1,24 @@
 <!DOCTYPE html>
 <html lang="es">
+  <head>
+    <meta charset="UTC-8" />
+    <title>English Team</title>
+    <link rel="stylesheet" href="../style.css" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.3/flowbite.min.css" rel="stylesheet"/>
+  </head>
 
-<head>
-<meta charset="UTC-8">
-<title>English Team</title>
-<link rel="stylesheet" href="../style.css">
-</head>
-
-<body>
-
-<div><img src="../imagenes/logo_sd.png" alt="logo SD"></div>
+  <body class="flex justify-center items-center h-screen">
+    <div class="max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
+        <a href="#">
+            <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">TECNICOS DE GUARDIA</h5>
+        </a>
+        <p class="mb-3 font-normal text-gray-700 dark:text-gray-400">informacion que se va a mostrar.</p>
+        <a href="#" class="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
+            Atras
+        </a>
+        <a href="#" class="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
+            Siguiente
+        </a>
+    </div>
+  </body>
+</html>

--- a/indice/validaciones.html
+++ b/indice/validaciones.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang="es">
+  <head>
+    <meta charset="UTC-8" />
+    <title>English Team</title>
+    <link rel="stylesheet" href="../style.css" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.3/flowbite.min.css" rel="stylesheet" />
+  </head>
 
-<head>
-<meta charset="UTC-8">
-<title>English Team</title>
-<link rel="stylesheet" href="../style.css">
-</head>
-
-<body>
-
-<div><img src="../imagenes/logo_sd.png" alt="logo SD"></div>
+  <body>
+    <div><img src="../imagenes/logo_sd.png" alt="logo SD" /></div>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -9,7 +9,9 @@ body > div.buttons {
   justify-content: center;
   align-items: center;
   height: 30rem;
-  gap: 10px; 
+  width: 60rem;
+  gap: 25px;
+  margin: 0 auto;
 }
 
 body > div.buttons > div.btn {

--- a/tarjetas/robos.html
+++ b/tarjetas/robos.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html lang="es">
-  <head>
-    <meta charset="UTC-8" />
-    <title>English Team</title>
-    <link rel="stylesheet" href="../style.css" />
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.3/flowbite.min.css" rel="stylesheet" />
-  </head>
-
-  <body class="flex justify-center items-center h-screen">
+    <title>Document</title>
+</head>
+<body class="flex justify-center items-center h-screen">
     <div class="max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
         <a href="#">
             <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">ROBOS</h5>
         </a>
-        <p class="mb-3 font-normal text-gray-700 dark:text-gray-400">informacion que se va a mostrar.</p>
+        <p class="mb-3 font-normal text-gray-700 dark:text-gray-400">informacion.</p>
         <a href="#" class="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
             Atras
         </a>

--- a/tarjetas/robos.html
+++ b/tarjetas/robos.html
@@ -12,7 +12,7 @@
         <a href="#">
             <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">ROBOS</h5>
         </a>
-        <p class="mb-3 font-normal text-gray-700 dark:text-gray-400">informacion.</p>
+        <p class="mb-3 font-normal text-gray-700 dark:text-gray-400">informacion a colocar.</p>
         <a href="#" class="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
             Atras
         </a>


### PR DESCRIPTION
The index.html has a new class names, **TARJETAS** folder was added with a card called **Robos.html**. Each html file in the **INDICE** folder has been updated with the new _flowbite library_, for css styles in each file.  You just to add the card code from the robos.html or flowbite templates to see how it looks.

Don't forget to run `npm install -g gulp-cli` before to use `gulp serve`

In the next link you can see all the components that you can use
[flowbite components](https://flowbite.com/docs/components/card/).

In Flowbite the styles it's been defined by the class tag:

> For example
> A _div_ component with the class called **block**, it's means that div has set the style **display block** without any style.css created
> `<div class="block"></div>`
> ```
> div.block: {
>    display: block
> }
> ```